### PR TITLE
quickselect: implement several optimizations

### DIFF
--- a/quickselect_test.go
+++ b/quickselect_test.go
@@ -31,7 +31,7 @@ func TestQuickSelectWithSimpleArray(t *testing.T) {
 	smallestK := fixture.Array[:5]
 	expectedK := []int{2, 3, 4, 5, 6}
 	if !hasSameElements(smallestK, expectedK) {
-		t.Errorf("Expected smallest K elements to be '%s', but got '%s'", expectedK, smallestK)
+		t.Errorf("Expected smallest K elements to be '%v', but got '%v'", expectedK, smallestK)
 	}
 }
 
@@ -45,7 +45,7 @@ func TestQuickSelectWithRepeatedElements(t *testing.T) {
 	smallestK := fixture.Array[:5]
 	expectedK := []int{2, 2, 2, 3, 3}
 	if !hasSameElements(smallestK, expectedK) {
-		t.Errorf("Expected smallest K elements to be '%s', but got '%s'", expectedK, smallestK)
+		t.Errorf("Expected smallest K elements to be '%v', but got '%v'", expectedK, smallestK)
 	}
 }
 
@@ -85,7 +85,7 @@ func TestIntSliceQuickSelect(t *testing.T) {
 
 		resultK := fixture.Array[:4]
 		if !hasSameElements(resultK, fixture.ExpectedK) {
-			t.Errorf("Expected smallest K elements to be '%s', but got '%s'", fixture.ExpectedK, resultK)
+			t.Errorf("Expected smallest K elements to be '%v', but got '%v'", fixture.ExpectedK, resultK)
 		}
 	}
 }
@@ -131,7 +131,7 @@ func TestNaiveSelectionFinding(t *testing.T) {
 
 		resultK := fixture.Array[:4]
 		if !hasSameElements(resultK, fixture.ExpectedK) {
-			t.Errorf("Expected smallest K elements to be '%s', but got '%s'", fixture.ExpectedK, resultK)
+			t.Errorf("Expected smallest K elements to be '%v', but got '%v'", fixture.ExpectedK, resultK)
 		}
 	}
 }
@@ -153,7 +153,7 @@ func TestHeapSelectionFinding(t *testing.T) {
 
 		resultK := fixture.Array[:4]
 		if !hasSameElements(resultK, fixture.ExpectedK) {
-			t.Errorf("Expected smallest K elements to be '%s', but got '%s'", fixture.ExpectedK, resultK)
+			t.Errorf("Expected smallest K elements to be '%v', but got '%v'", fixture.ExpectedK, resultK)
 		}
 	}
 }
@@ -176,7 +176,7 @@ func TestFloat64SliceQuickSelect(t *testing.T) {
 
 		resultK := fixture.Array[:4]
 		if !hasSameElementsFloat64(resultK, fixture.ExpectedK) {
-			t.Errorf("Expected smallest K elements to be '%s', but got '%s'", fixture.ExpectedK, resultK)
+			t.Errorf("Expected smallest K elements to be '%v', but got '%v'", fixture.ExpectedK, resultK)
 		}
 	}
 }


### PR DESCRIPTION
This commit implements a few optimizations of bottlenecks that showed up in profiles:

1. Use math/rand/v2 which doesn't use global package level mutex.
2. Roll our own heap that avoids tons of spurious `interface{}` allocations.
3. Reduce calls to data.Len() in loops


### Benchmarks

```
goos: darwin
goarch: arm64
pkg: github.com/wangjohn/quickselect
cpu: Apple M3 Max
                       │  before.txt  │              after.txt              │
                       │    sec/op    │    sec/op     vs base               │
QuickSelectSize1e2K1e1   11.03µ ± 14%   10.53µ ± 25%        ~ (p=0.394 n=6)
QuickSelectSize1e3K1e1   76.03µ ±  2%   77.13µ ±  1%   +1.45% (p=0.002 n=6)
QuickSelectSize1e3K1e2   95.43µ ±  0%   92.60µ ± 50%        ~ (p=0.065 n=6)
QuickSelectSize1e4K1e1   254.6µ ±  0%   158.7µ ± 17%  -37.66% (p=0.002 n=6)
QuickSelectSize1e4K1e2   690.2µ ±  1%   669.6µ ±  1%   -2.98% (p=0.002 n=6)
QuickSelectSize1e4K1e3   873.7µ ± 54%   838.6µ ±  1%   -4.01% (p=0.002 n=6)
QuickSelectSize1e5K1e1   2.695m ± 28%   1.345m ±  2%  -50.10% (p=0.002 n=6)
QuickSelectSize1e5K1e2   2.823m ± 11%   1.489m ±  1%  -47.27% (p=0.002 n=6)
QuickSelectSize1e5K1e3   6.701m ±  2%   6.527m ±  1%   -2.59% (p=0.002 n=6)
QuickSelectSize1e5K1e4   8.297m ±  2%   8.137m ±  2%        ~ (p=0.093 n=6)
QuickSelectSize1e6K1e1   20.54m ±  2%   13.62m ±  4%  -33.67% (p=0.002 n=6)
QuickSelectSize1e6K1e2   21.53m ±  0%   12.46m ±  1%  -42.13% (p=0.002 n=6)
QuickSelectSize1e6K1e3   33.24m ±  1%   21.37m ±  1%  -35.70% (p=0.002 n=6)
QuickSelectSize1e6K1e4   64.61m ±  9%   65.39m ±  9%        ~ (p=0.485 n=6)
QuickSelectSize1e6K1e5   81.06m ±  4%   84.44m ±  5%        ~ (p=0.132 n=6)
QuickSelectSize1e7K1e1   207.4m ±  2%   133.5m ± 13%  -35.61% (p=0.002 n=6)
QuickSelectSize1e7K1e2   210.2m ±  1%   113.7m ±  2%  -45.93% (p=0.002 n=6)
QuickSelectSize1e7K1e3   227.1m ±  7%   125.5m ±  2%  -44.74% (p=0.002 n=6)
QuickSelectSize1e7K1e4   611.6m ± 13%   638.6m ± 20%        ~ (p=0.394 n=6)
QuickSelectSize1e7K1e5   628.0m ± 14%   688.6m ± 16%   +9.66% (p=0.026 n=6)
QuickSelectSize1e7K1e6   810.4m ±  8%   753.2m ± 19%        ~ (p=0.394 n=6)
QuickSelectSize1e8K1e1    2.116 ±  2%    1.159 ±  8%  -45.24% (p=0.002 n=6)
QuickSelectSize1e8K1e2    2.107 ±  1%    1.105 ±  1%  -47.54% (p=0.002 n=6)
QuickSelectSize1e8K1e3    2.123 ±  4%    1.120 ±  2%  -47.25% (p=0.002 n=6)
QuickSelectSize1e8K1e4    6.335 ± 15%    7.050 ± 23%  +11.29% (p=0.041 n=6)
QuickSelectSize1e8K1e5    5.613 ± 52%    5.481 ± 36%        ~ (p=0.937 n=6)
QuickSelectSize1e8K1e6    6.543 ± 31%    5.869 ± 19%        ~ (p=0.394 n=6)
QuickSelectSize1e8K1e7    8.155 ± 12%    8.546 ± 37%        ~ (p=0.240 n=6)
SortSize1e2K1e1          24.66µ ±  6%   24.88µ ±  8%        ~ (p=0.818 n=6)
SortSize1e3K1e1          358.3µ ±  0%   368.7µ ±  5%   +2.92% (p=0.002 n=6)
SortSize1e4K1e1          4.717m ±  2%   4.445m ±  0%   -5.76% (p=0.002 n=6)
SortSize1e5K1e1          58.74m ±  4%   56.21m ±  0%   -4.31% (p=0.026 n=6)
SortSize1e6K1e1          747.9m ±  4%   679.9m ±  0%   -9.09% (p=0.002 n=6)
SortSize1e7K1e1           7.935 ±  0%    7.965 ±  1%   +0.38% (p=0.009 n=6)
SortSize1e8K1e1           92.41 ±  1%    92.49 ±  1%        ~ (p=0.818 n=6)
geomean                  46.85m         38.42m        -17.99%

                       │   before.txt   │               after.txt               │
                       │      B/op      │     B/op      vs base                 │
QuickSelectSize1e2K1e1       896.0 ± 0%     896.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e3K1e1       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e3K1e2       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e4K1e1      5642.0 ± 0%     896.0 ± 0%  -84.12% (p=0.002 n=6)
QuickSelectSize1e4K1e2       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e4K1e3       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e5K1e1      8206.5 ± 0%     896.0 ± 0%  -89.08% (p=0.002 n=6)
QuickSelectSize1e5K1e2    78.572Ki ± 0%   6.453Ki ± 0%  -91.79% (p=0.002 n=6)
QuickSelectSize1e5K1e3       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e5K1e4       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e6K1e1     10813.0 ± 0%     896.0 ± 0%  -91.71% (p=0.002 n=6)
QuickSelectSize1e6K1e2   103.665Ki ± 0%   6.453Ki ± 0%  -93.77% (p=0.002 n=6)
QuickSelectSize1e6K1e3    881.11Ki ± 0%   56.33Ki ± 0%  -93.61% (p=0.002 n=6)
QuickSelectSize1e6K1e4       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e6K1e5       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e7K1e1     13270.0 ± 0%     896.0 ± 0%  -93.25% (p=0.002 n=6)
QuickSelectSize1e7K1e2   128.156Ki ± 0%   6.453Ki ± 0%  -94.96% (p=0.002 n=6)
QuickSelectSize1e7K1e3   1132.82Ki ± 0%   56.33Ki ± 0%  -95.03% (p=0.002 n=6)
QuickSelectSize1e7K1e4       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e7K1e5       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e7K1e6       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e8K1e1     16048.0 ± 0%     896.0 ± 0%  -94.42% (p=0.002 n=6)
QuickSelectSize1e8K1e2   154.719Ki ± 0%   6.453Ki ± 0%  -95.83% (p=0.002 n=6)
QuickSelectSize1e8K1e3   1386.89Ki ± 0%   56.33Ki ± 0%  -95.94% (p=0.002 n=6)
QuickSelectSize1e8K1e4       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e8K1e5       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e8K1e6       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e8K1e7       168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e2K1e1              168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e3K1e1              168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e4K1e1              168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e5K1e1              168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e6K1e1              168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e7K1e1              168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e8K1e1              168.0 ± 0%     168.0 ± 0%        ~ (p=1.000 n=6) ¹
geomean                    1.389Ki          561.8       -60.51%
¹ all samples are equal

                       │   before.txt   │              after.txt              │
                       │   allocs/op    │ allocs/op   vs base                 │
QuickSelectSize1e2K1e1       21.00 ± 0%   21.00 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e3K1e1       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e3K1e2       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e4K1e1      445.00 ± 0%   21.00 ± 0%  -95.28% (p=0.002 n=6)
QuickSelectSize1e4K1e2       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e4K1e3       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e5K1e1      766.00 ± 0%   21.00 ± 0%  -97.26% (p=0.002 n=6)
QuickSelectSize1e5K1e2     7655.00 ± 0%   21.00 ± 0%  -99.73% (p=0.002 n=6)
QuickSelectSize1e5K1e3       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e5K1e4       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e6K1e1     1092.00 ± 0%   21.00 ± 0%  -98.08% (p=0.002 n=6)
QuickSelectSize1e6K1e2    10867.00 ± 0%   21.00 ± 0%  -99.81% (p=0.002 n=6)
QuickSelectSize1e6K1e3    94811.00 ± 0%   21.00 ± 0%  -99.98% (p=0.002 n=6)
QuickSelectSize1e6K1e4       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e6K1e5       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e7K1e1     1399.00 ± 0%   21.00 ± 0%  -98.50% (p=0.002 n=6)
QuickSelectSize1e7K1e2    14003.00 ± 0%   21.00 ± 0%  -99.85% (p=0.002 n=6)
QuickSelectSize1e7K1e3   127032.00 ± 0%   21.00 ± 0%  -99.98% (p=0.002 n=6)
QuickSelectSize1e7K1e4       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e7K1e5       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e7K1e6       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e8K1e1     1747.00 ± 0%   21.00 ± 0%  -98.80% (p=0.002 n=6)
QuickSelectSize1e8K1e2    17403.00 ± 0%   21.00 ± 0%  -99.88% (p=0.002 n=6)
QuickSelectSize1e8K1e3   159553.00 ± 0%   21.00 ± 0%  -99.99% (p=0.002 n=6)
QuickSelectSize1e8K1e4       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e8K1e5       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e8K1e6       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
QuickSelectSize1e8K1e7       7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e2K1e1              7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e3K1e1              7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e4K1e1              7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e5K1e1              7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e6K1e1              7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e7K1e1              7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
SortSize1e8K1e1              7.000 ± 0%   7.000 ± 0%        ~ (p=1.000 n=6) ¹
geomean                      79.24        10.53       -86.72%
¹ all samples are equal
```